### PR TITLE
fix: 修正 setup_services.sh 自動替換 service 檔案中的路徑

### DIFF
--- a/setup_services.sh
+++ b/setup_services.sh
@@ -22,6 +22,11 @@ echo "Copying configuration files to /etc/systemd/system/ ..."
 cp "$SCRIPT_DIR/meshbridge-wifi.service" /etc/systemd/system/
 cp "$SCRIPT_DIR/meshbridge.service" /etc/systemd/system/
 
+# Replace hardcoded paths with actual script directory
+echo "Updating paths in service files..."
+sed -i "s|/home/pi/MeshBridge|$SCRIPT_DIR|g" /etc/systemd/system/meshbridge-wifi.service
+sed -i "s|/home/pi/MeshBridge|$SCRIPT_DIR|g" /etc/systemd/system/meshbridge.service
+
 # Set permissions (standard is 644)
 chmod 644 /etc/systemd/system/meshbridge-wifi.service
 chmod 644 /etc/systemd/system/meshbridge.service


### PR DESCRIPTION
- 複製 service 檔案後，使用 sed 將硬編碼的 /home/pi/MeshBridge 替換為實際的 $SCRIPT_DIR
- 確保無論專案放在哪個目錄都能正確運行
- 影響檔案：meshbridge-wifi.service 和 meshbridge.service